### PR TITLE
Add HTTPS Redirect listener rules and update defaule SSL policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module deploys an Application Load Balancer with associated resources, such
 
 ```
 module "alb" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.0.8"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.0.9"
 
  alb_name        = "MyALB"
  security_groups = ["${module.sg.public_web_security_group_id}"]
@@ -42,6 +42,7 @@ Full working references are available at [examples](examples)
 | create\_logging\_bucket | Create a new S3 logging bucket. i.e. true | false | string | `"true"` | no |
 | enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | string | `"false"` | no |
 | enable\_http2 | If true sets HTTP/2 to enabled. | string | `"true"` | no |
+| enable\_https\_redirect | If true and at least one HTTP and one HTTPS listener is created, HTTP listeners will have a redirect rule created to forward all traffic to the first HTTPS listener. | string | `"false"` | no |
 | environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `"Development"` | no |
 | extra\_ssl\_certs | A list of maps describing any extra SSL certificates to apply to the HTTPS listeners. Certificates must be in the same region as the ALB. Required key/values: certificate_arn, https_listener_index (the index of the listener within https_listeners which the cert applies toward). [{'certificate_arn', 'arn:aws:iam::123456789012:server-certificate/other_test_cert-123456789012', 'https_listener_index', 1}] | list | `<list>` | no |
 | extra\_ssl\_certs\_count | The number of extra ssl certs to be added. | string | `"0"` | no |

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -33,7 +33,7 @@ resource "aws_security_group" "test_sg" {
 }
 
 module "vpc" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.9"
   az_count            = 2
   cidr_range          = "10.0.0.0/16"
   public_cidr_ranges  = ["10.0.1.0/24", "10.0.3.0/24"]
@@ -42,7 +42,7 @@ module "vpc" {
 }
 
 module "alb" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.0.8"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.0.9"
 
   # Required
   alb_name        = "${random_string.rstring.result}-test-alb"

--- a/tests/multiple_http_https_cw_targets/main.tf
+++ b/tests/multiple_http_https_cw_targets/main.tf
@@ -86,7 +86,8 @@ module "alb" {
     "LeftSaid"  = "George"
   }
 
-  http_listeners_count = 2
+  enable_https_redirect = true
+  http_listeners_count  = 2
 
   http_listeners = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "enable_http2" {
   default     = true
 }
 
+variable "enable_https_redirect" {
+  description = "If true and at least one HTTP and one HTTPS listener is created, HTTP listeners will have a redirect rule created to forward all traffic to the first HTTPS listener."
+  type        = "string"
+  default     = false
+}
+
 variable "environment" {
   description = "Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test')"
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
Fixes #213
##### Summary of change(s):

- Adds capability to enable HTTPS redirects.  Option controlled by boolean variable and only enabled if at least one HTTP and at least one HTTPS listener is enabled.
- Adds default SSL policy of `ELBSecurityPolicy-TLS-1-2-2017-01`

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Readme updated
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.