### PR TITLE
Add lifecycle rule to abort multipart uploads on logging bucket (HCL2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module deploys an Application Load Balancer with associated resources, such
 
 ```HCL
 module "alb" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.5"
 
   http_listeners_count = 1
   name                 = "MyALB"

--- a/examples/complex.tf
+++ b/examples/complex.tf
@@ -60,7 +60,7 @@ module "vpc" {
 }
 
 module "alb" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.5"
 
   name                        = "${random_string.rstring.result}-test-alb"
   create_internal_zone_record = true

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -55,7 +55,7 @@ module "vpc" {
 }
 
 module "alb" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.5"
 
   create_internal_zone_record = true
   create_logging_bucket       = false

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@
  *
  * ```HCL
  * module "alb" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.3"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-alb//?ref=v0.12.5"
  *
  *   http_listeners_count = 1
  *   name                 = "MyALB"
@@ -252,6 +252,14 @@ resource "aws_s3_bucket" "log_bucket" {
     expiration {
       days = var.logging_bucket_retention
     }
+  }
+
+  lifecycle_rule {
+    abort_incomplete_multipart_upload_days = 7
+    enabled                                = true
+    id                                     = "rax-cleanup-incomplete-mpu-objects"
+
+    expiration {}
   }
 
   server_side_encryption_configuration {


### PR DESCRIPTION
##### Corresponding Issue(s):
 - https://jira.rax.io/browse/MPCSUPENG-1601 (HCL2)

##### Summary of change(s):
Adds  S3 lifecycle rule to cleanup Multipart uploads on logging bucket to prevent drift when rule is applied by automation that creates this rule on existing buckets

##### Reason for Change(s):

- Eliminate manual drift within the IaC managed environment

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stakeholders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
