### PR TITLE
Prevent creation of NAT gateways

### DIFF
--- a/tests/default/main.tf
+++ b/tests/default/main.tf
@@ -39,9 +39,10 @@ resource "aws_security_group" "test_sg" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
 
-  az_count   = 2
-  cidr_range = "10.0.0.0/16"
-  name       = "${random_string.rstring.result}-test"
+  az_count           = 2
+  build_nat_gateways = false
+  cidr_range         = "10.0.0.0/16"
+  name               = "${random_string.rstring.result}-test"
 
   private_cidr_ranges = [
     "10.0.2.0/24",

--- a/tests/multiple_http_https_cw_targets/main.tf
+++ b/tests/multiple_http_https_cw_targets/main.tf
@@ -39,9 +39,10 @@ resource "aws_security_group" "test_sg" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
 
-  az_count   = 2
-  cidr_range = "10.0.0.0/16"
-  name       = "${random_string.rstring.result}-test"
+  az_count           = 2
+  build_nat_gateways = false
+  cidr_range         = "10.0.0.0/16"
+  name               = "${random_string.rstring.result}-test"
 
   private_cidr_ranges = [
     "10.0.2.0/24",

--- a/tests/multiple_target_groups/main.tf
+++ b/tests/multiple_target_groups/main.tf
@@ -39,9 +39,10 @@ resource "aws_security_group" "test_sg" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
 
-  az_count   = 2
-  cidr_range = "10.0.0.0/16"
-  name       = "${random_string.rstring.result}-test"
+  az_count           = 2
+  build_nat_gateways = false
+  cidr_range         = "10.0.0.0/16"
+  name               = "${random_string.rstring.result}-test"
 
   private_cidr_ranges = [
     "10.0.2.0/24",

--- a/tests/zone_single_listener/main.tf
+++ b/tests/zone_single_listener/main.tf
@@ -39,9 +39,10 @@ resource "aws_security_group" "test_sg" {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
 
-  az_count   = 2
-  cidr_range = "10.0.0.0/16"
-  name       = "${random_string.rstring.result}-test"
+  az_count           = 2
+  build_nat_gateways = false
+  cidr_range         = "10.0.0.0/16"
+  name               = "${random_string.rstring.result}-test"
 
   private_cidr_ranges = [
     "10.0.2.0/24",


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):

Prevent creation of NAT gateways when using the `aws-terraform-vpc_basenetwork` module.

##### Reason for Change(s):

None of the test cases require NAT gateways
- The EC2 instances created in the `multiple_http_https_cw_targets` test use the latest version of a public AMI and do not have `userdata`; there is no defined need for these instances to have outbound access.
- The remaining tests do not require outbound access.

Preventing creation of the NAT gateways will reduce the cost of testing; there may be a small benefit in time-to-complete the `terraform apply` part of the testing process, although with parallesiation of resource creation this is difficult to quantify.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No; changes are being made to test cases, not module code.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Potentially. If the `aws-terraform-vpc_basenetwork` module renames or changes behavior of the `build_nat_gateway` flag, then pinning in this module may need to be updated.

##### If input variables or output variables have changed or has been added, have you updated the README?

N/A

##### Do examples need to be updated based on changes?

No.


##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
