### PR TITLE
Permit customer alarms to be explicitly enabled instead of implicitly…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The following module variables were updated to better meet current Rackspace sty
 | add\_waf | Add an existing Regional WAF to the ALB. true \| false | `bool` | `false` | no |
 | create\_internal\_zone\_record | Create Route 53 internal zone record for the ALB. i.e true \| false | `bool` | `false` | no |
 | create\_logging\_bucket | Create a new S3 logging bucket. i.e. true \| false | `bool` | `true` | no |
+| customer\_alarms\_cleared | Specifies whether alarms will notify customers when returning to an OK status. | `bool` | `false` | no |
+| customer\_alarms\_enabled | Specifies whether alarms will notify customers.  Automatically enabled if rackspace\_managed is set to false | `bool` | `false` | no |
 | enable\_deletion\_protection | If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false. | `bool` | `false` | no |
 | enable\_http2 | If true sets HTTP/2 to enabled. | `bool` | `true` | no |
 | enable\_https\_redirect | If true and at least one HTTP and one HTTPS listener is created, HTTP listeners will have a redirect rule created to forward all traffic to the first HTTPS listener. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -330,6 +330,8 @@ module "unhealthy_host_count_alarm" {
   alarm_description        = "Unhealthy Host count is greater than or equal to threshold, creating ticket."
   alarm_name               = "${var.name}_unhealthy_host_count_alarm"
   comparison_operator      = "GreaterThanOrEqualToThreshold"
+  customer_alarms_cleared  = var.customer_alarms_cleared
+  customer_alarms_enabled  = var.customer_alarms_enabled
   dimensions               = data.null_data_source.alarm_dimensions.*.outputs
   evaluation_periods       = 10
   metric_name              = "UnHealthyHostCount"

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,18 @@ variable "create_logging_bucket" {
   default     = true
 }
 
+variable "customer_alarms_cleared" {
+  description = "Specifies whether alarms will notify customers when returning to an OK status."
+  type        = bool
+  default     = false
+}
+
+variable "customer_alarms_enabled" {
+  description = "Specifies whether alarms will notify customers.  Automatically enabled if rackspace_managed is set to false"
+  type        = bool
+  default     = false
+}
+
 variable "enable_deletion_protection" {
   description = "If true, deletion of the load balancer will be disabled via the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to false."
   type        = bool


### PR DESCRIPTION
… via rackspace_managed = false

##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):

This change permits customer notifications for ALB alarms to be enabled explicitly and independently of the `rackspace_managed` setting.

##### Reason for Change(s):

The ALB module allows a customer/additional `notification_topic` to be specified for notifying of Cloudwatch alarms, but this is used _only_  when`rackspace_managed` is set to `false`. In other words, either the customer *or* Rackspace is notified, but not both.

This change allows both Rackspace and a customer to receive notifications.  This more accurately reflects both past and current support offerings (i.e. solely managed by Rackspace, managed in partnership with customer).


- If a bug, describe error scenario, including expected behavior and actual behavior.

- If an enhancement, describe the use case and the perceived benefit(s).

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No resource destruction or replacement will be triggered by this change. The PR preserves the previous behavior. Enabling the "new" behaviour requires explicit changes in the ALB module usage; modifying `alarm_actions` and/or `ok_actions` in a Terraform `aws_cloudwatch_metric_alarm` is an in-place change.


##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Not directly; this change brings the ALB module somewhat more in line with other Rackspace Terraform modules
such as `aws-terraform-rds` which hard-codes `customer_alarms_enable = true`. When working on this PR, I considered using the same approach but reached the conclusion that hard-coding either way was not justified (inflexible, requires forks to adapt).

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes.

##### Do examples need to be updated based on changes?

No.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
